### PR TITLE
Fix: Update Ramstack.Globbing to version 2.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="MinVer" Version="5.0.0" />
     <PackageVersion Include="NUnit" Version="4.1.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageVersion Include="Ramstack.Globbing" Version="2.2.0-preview.3" />
+    <PackageVersion Include="Ramstack.Globbing" Version="2.2.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Addresses an oversight where the package version wasn't updated before publication.