### PR TITLE
Skip enumeration entirely for excluded directories

### DIFF
--- a/src/Ramstack.FileSystem.Globbing/GlobbingDirectory.cs
+++ b/src/Ramstack.FileSystem.Globbing/GlobbingDirectory.cs
@@ -56,18 +56,21 @@ internal sealed class GlobbingDirectory : VirtualDirectory
     /// <inheritdoc />
     protected override async IAsyncEnumerable<VirtualNode> GetFileNodesCoreAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        await foreach (var node in _directory.GetFileNodesAsync(cancellationToken).ConfigureAwait(false))
+        if (_included)
         {
-            if (!_fs.IsExcluded(node.FullName))
+            await foreach (var node in _directory.GetFileNodesAsync(cancellationToken).ConfigureAwait(false))
             {
-                if (node is VirtualFile file)
+                if (!_fs.IsExcluded(node.FullName))
                 {
-                    if (_fs.IsIncluded(node.FullName))
-                        yield return new GlobbingFile(_fs, file, true);
-                }
-                else
-                {
-                    yield return new GlobbingDirectory(_fs, (VirtualDirectory)node, true);
+                    if (node is VirtualFile file)
+                    {
+                        if (_fs.IsIncluded(node.FullName))
+                            yield return new GlobbingFile(_fs, file, true);
+                    }
+                    else
+                    {
+                        yield return new GlobbingDirectory(_fs, (VirtualDirectory)node, true);
+                    }
                 }
             }
         }
@@ -76,20 +79,26 @@ internal sealed class GlobbingDirectory : VirtualDirectory
     /// <inheritdoc />
     protected override async IAsyncEnumerable<VirtualFile> GetFilesCoreAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        await foreach (var file in _directory.GetFilesAsync(cancellationToken).ConfigureAwait(false))
+        if (_included)
         {
-            if (_fs.IsFileIncluded(file.FullName))
-                yield return new GlobbingFile(_fs, file, true);
+            await foreach (var file in _directory.GetFilesAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (_fs.IsFileIncluded(file.FullName))
+                    yield return new GlobbingFile(_fs, file, true);
+            }
         }
     }
 
     /// <inheritdoc />
     protected override async IAsyncEnumerable<VirtualDirectory> GetDirectoriesCoreAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        await foreach (var directory in _directory.GetDirectoriesAsync(cancellationToken).ConfigureAwait(false))
+        if (_included)
         {
-            if (_fs.IsDirectoryIncluded(directory.FullName))
-                yield return new GlobbingDirectory(_fs, directory, true);
+            await foreach (var directory in _directory.GetDirectoriesAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (_fs.IsDirectoryIncluded(directory.FullName))
+                    yield return new GlobbingDirectory(_fs, directory, true);
+            }
         }
     }
 }

--- a/tests/Ramstack.FileSystem.Globbing.Tests/GlobingFileSystemTests.cs
+++ b/tests/Ramstack.FileSystem.Globbing.Tests/GlobingFileSystemTests.cs
@@ -29,6 +29,57 @@ public class GlobingFileSystemTests : VirtualFileSystemSpecificationTests
     public void Cleanup() =>
         _storage.Dispose();
 
+    [Test]
+    public async Task ExcludedDirectory_HasNoFileNodes()
+    {
+        using var storage = new TempFileStorage();
+        using var fs = new GlobbingFileSystem(new PhysicalFileSystem(storage.Root), "**", exclude: "/project/src/**");
+
+        var directories = new[]
+        {
+            "/project/src",
+            "/project/src/App",
+            "/project/src/Modules",
+            "/project/src/Modules/Module1",
+            "/project/src/Modules/Module1/Submodule",
+            "/project/src/Modules/Module2"
+        };
+
+        foreach (var path in directories)
+        {
+            var directory = fs.GetDirectory(path);
+
+            Assert.That(
+                await directory.ExistsAsync(),
+                Is.False);
+
+            Assert.That(
+                await directory.GetFileNodesAsync("**").CountAsync(),
+                Is.Zero);
+        }
+
+        var files = new[]
+        {
+            "/project/src/App/App.csproj",
+            "/project/src/App/Program.cs",
+            "/project/src/App/Utils.cs",
+            "/project/src/Modules/Module1/Module1.cs",
+            "/project/src/Modules/Module1/Module1.csproj",
+            "/project/src/Modules/Module1/Submodule/Submodule1.cs",
+            "/project/src/Modules/Module1/Submodule/Submodule2.cs",
+            "/project/src/Modules/Module1/Submodule/Submodule.csproj",
+            "/project/src/Modules/Module2/Module2.cs",
+            "/project/src/Modules/Module2/Module2.csproj",
+            "/project/src/App.sln"
+        };
+
+        foreach (var path in files)
+        {
+            var file = fs.GetFile(path);
+            Assert.That(await file.ExistsAsync(), Is.False);
+        }
+    }
+
     protected override IVirtualFileSystem GetFileSystem()
     {
         var fs = new PhysicalFileSystem(_storage.Root);


### PR DESCRIPTION
Skip enumeration entirely in `GlobbingDirectory` when a directory is excluded. Previously, the code would still iterate through file nodes even if the directory wasn't included, doing unnecessary work.

No functional changes - just optimization and clarity.