### PR TITLE
Improve code quality and test performance

### DIFF
--- a/src/Ramstack.FileSystem.Abstractions/VirtualNode.cs
+++ b/src/Ramstack.FileSystem.Abstractions/VirtualNode.cs
@@ -41,7 +41,7 @@ public abstract class VirtualNode
     /// <param name="path">The full path of the file or directory.</param>
     protected VirtualNode(string path)
     {
-        Debug.Assert(path == VirtualPath.Normalize(path));
+        Debug.Assert(VirtualPath.IsNormalized(path));
         FullName = path;
     }
 

--- a/src/Ramstack.FileSystem.Abstractions/VirtualNodeProperties.cs
+++ b/src/Ramstack.FileSystem.Abstractions/VirtualNodeProperties.cs
@@ -9,10 +9,16 @@ namespace Ramstack.FileSystem;
 public sealed class VirtualNodeProperties
 {
     /// <summary>
-    /// Gets an instance of <see cref="VirtualNodeProperties"/> that represents a node with no data or an unavailable state.
+    /// Gets an instance of <see cref="VirtualNodeProperties"/> that represents a node with an unavailable state.
     /// </summary>
     public static VirtualNodeProperties Unavailable { get; } =
         new VirtualNodeProperties(default, default, default, -1);
+
+    /// <summary>
+    /// Gets an instance of <see cref="VirtualNodeProperties"/> that represents a node with no data.
+    /// </summary>
+    public static VirtualNodeProperties None { get; } =
+        new VirtualNodeProperties(default, default, default, 0);
 
     /// <summary>
     /// Gets the time when the current file or directory was created.

--- a/src/Ramstack.FileSystem.Adapters/VirtualDirectoryAdapter.cs
+++ b/src/Ramstack.FileSystem.Adapters/VirtualDirectoryAdapter.cs
@@ -46,8 +46,8 @@ internal sealed class VirtualDirectoryAdapter : VirtualDirectory
     protected override ValueTask<VirtualNodeProperties?> GetPropertiesCoreAsync(CancellationToken cancellationToken)
     {
         var properties = _file?.Exists ?? _directory!.Exists
-            ? VirtualNodeProperties.CreateDirectoryProperties(default, default, default)
-            : null;
+            ? VirtualNodeProperties.None
+            : VirtualNodeProperties.Unavailable;
 
         return new ValueTask<VirtualNodeProperties?>(properties);
     }

--- a/src/Ramstack.FileSystem.Amazon/S3Directory.cs
+++ b/src/Ramstack.FileSystem.Amazon/S3Directory.cs
@@ -24,7 +24,7 @@ internal sealed class S3Directory : VirtualDirectory
     public S3Directory(AmazonS3FileSystem fileSystem, string path) : base(path)
     {
         _fs = fileSystem;
-        _prefix = FullName == "/" ? "" : $"{FullName[1..]}/";
+        _prefix = path == "/" ? "" : $"{path[1..]}/";
     }
 
     /// <inheritdoc />

--- a/src/Ramstack.FileSystem.Amazon/S3Directory.cs
+++ b/src/Ramstack.FileSystem.Amazon/S3Directory.cs
@@ -28,11 +28,8 @@ internal sealed class S3Directory : VirtualDirectory
     }
 
     /// <inheritdoc />
-    protected override ValueTask<VirtualNodeProperties?> GetPropertiesCoreAsync(CancellationToken cancellationToken)
-    {
-        var properties = VirtualNodeProperties.CreateDirectoryProperties(default, default, default);
-        return new ValueTask<VirtualNodeProperties?>(properties);
-    }
+    protected override ValueTask<VirtualNodeProperties?> GetPropertiesCoreAsync(CancellationToken cancellationToken) =>
+        new ValueTask<VirtualNodeProperties?>(VirtualNodeProperties.None);
 
     /// <inheritdoc />
     protected override ValueTask CreateCoreAsync(CancellationToken cancellationToken) =>

--- a/src/Ramstack.FileSystem.Amazon/S3UploadStream.cs
+++ b/src/Ramstack.FileSystem.Amazon/S3UploadStream.cs
@@ -92,13 +92,6 @@ internal sealed class S3UploadStream : Stream
     }
 
     /// <inheritdoc />
-    public override long Seek(long offset, SeekOrigin origin)
-    {
-        Error_NotSupported();
-        return 0;
-    }
-
-    /// <inheritdoc />
     public override void Write(byte[] buffer, int offset, int count) =>
         Write(buffer.AsSpan(offset, count));
 
@@ -137,6 +130,13 @@ internal sealed class S3UploadStream : Stream
             await AbortAsync(cancellationToken).ConfigureAwait(false);
             ExceptionDispatchInfo.Throw(exception);
         }
+    }
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        Error_NotSupported();
+        return 0;
     }
 
     /// <inheritdoc />

--- a/src/Ramstack.FileSystem.Azure/AzureDirectory.cs
+++ b/src/Ramstack.FileSystem.Azure/AzureDirectory.cs
@@ -27,11 +27,8 @@ internal sealed class AzureDirectory : VirtualDirectory
         _fs = fileSystem;
 
     /// <inheritdoc />
-    protected override ValueTask<VirtualNodeProperties?> GetPropertiesCoreAsync(CancellationToken cancellationToken)
-    {
-        var properties = VirtualNodeProperties.CreateDirectoryProperties(default, default, default);
-        return new ValueTask<VirtualNodeProperties?>(properties);
-    }
+    protected override ValueTask<VirtualNodeProperties?> GetPropertiesCoreAsync(CancellationToken cancellationToken) =>
+        new ValueTask<VirtualNodeProperties?>(VirtualNodeProperties.None);
 
     /// <inheritdoc />
     protected override ValueTask<bool> ExistsCoreAsync(CancellationToken cancellationToken) =>

--- a/src/Ramstack.FileSystem.Composite/CompositeDirectory.cs
+++ b/src/Ramstack.FileSystem.Composite/CompositeDirectory.cs
@@ -23,11 +23,8 @@ internal sealed class CompositeDirectory : VirtualDirectory
         _fs = fileSystem;
 
     /// <inheritdoc />
-    protected override ValueTask<VirtualNodeProperties?> GetPropertiesCoreAsync(CancellationToken cancellationToken)
-    {
-        var properties = VirtualNodeProperties.CreateDirectoryProperties(default, default, default);
-        return new ValueTask<VirtualNodeProperties?>(properties);
-    }
+    protected override ValueTask<VirtualNodeProperties?> GetPropertiesCoreAsync(CancellationToken cancellationToken) =>
+        new ValueTask<VirtualNodeProperties?>(VirtualNodeProperties.None);
 
     /// <inheritdoc />
     protected override ValueTask CreateCoreAsync(CancellationToken cancellationToken) =>

--- a/src/Ramstack.FileSystem.Prefixed/PrefixedFileSystem.cs
+++ b/src/Ramstack.FileSystem.Prefixed/PrefixedFileSystem.cs
@@ -130,11 +130,8 @@ public sealed class PrefixedFileSystem : IVirtualFileSystem
             (_fs, _directory) = (fileSystem, directory);
 
         /// <inheritdoc />
-        protected override ValueTask<VirtualNodeProperties?> GetPropertiesCoreAsync(CancellationToken cancellationToken)
-        {
-            var properties = VirtualNodeProperties.CreateDirectoryProperties(default, default, default);
-            return new ValueTask<VirtualNodeProperties?>(properties);
-        }
+        protected override ValueTask<VirtualNodeProperties?> GetPropertiesCoreAsync(CancellationToken cancellationToken) =>
+            new ValueTask<VirtualNodeProperties?>(VirtualNodeProperties.None);
 
         /// <inheritdoc />
         protected override ValueTask CreateCoreAsync(CancellationToken cancellationToken) =>

--- a/src/Ramstack.FileSystem.Zip/ZipDirectory.cs
+++ b/src/Ramstack.FileSystem.Zip/ZipDirectory.cs
@@ -20,16 +20,13 @@ internal sealed class ZipDirectory : VirtualDirectory
     /// Initializes a new instance of the <see cref="ZipDirectory"/> class.
     /// </summary>
     /// <param name="fileSystem">The file system associated with this directory.</param>
-    /// <param name="path">The path of directory.</param>
+    /// <param name="path">The path of the directory.</param>
     public ZipDirectory(ZipFileSystem fileSystem, string path) : base(path) =>
         _fileSystem = fileSystem;
 
     /// <inheritdoc />
-    protected override ValueTask<VirtualNodeProperties?> GetPropertiesCoreAsync(CancellationToken cancellationToken)
-    {
-        var properties = VirtualNodeProperties.CreateDirectoryProperties(default, default, default);
-        return new ValueTask<VirtualNodeProperties?>(properties);
-    }
+    protected override ValueTask<VirtualNodeProperties?> GetPropertiesCoreAsync(CancellationToken cancellationToken) =>
+        new ValueTask<VirtualNodeProperties?>(VirtualNodeProperties.None);
 
     /// <inheritdoc />
     protected override ValueTask<bool> ExistsCoreAsync(CancellationToken cancellationToken) =>

--- a/tests/Ramstack.FileSystem.Specification.Tests/VirtualFileSystemSpecificationTests.cs
+++ b/tests/Ramstack.FileSystem.Specification.Tests/VirtualFileSystemSpecificationTests.cs
@@ -65,8 +65,8 @@ public abstract class VirtualFileSystemSpecificationTests(string safePath = "/")
         using var fs = GetFileSystem();
 
         Assert.That(
-            await fs.GetFilesAsync("/", "**").CountAsync(),
-            Is.Not.Zero);
+            await fs.GetFilesAsync("/", "**").AnyAsync(),
+            Is.True);
 
         await foreach (var node in fs.GetFileNodesAsync("/", "**"))
         {
@@ -85,8 +85,8 @@ public abstract class VirtualFileSystemSpecificationTests(string safePath = "/")
         using var fs = GetFileSystem();
 
         Assert.That(
-            await fs.GetFilesAsync("/", "**").CountAsync(),
-            Is.Not.Zero);
+            await fs.GetFilesAsync("/", "**").AnyAsync(),
+            Is.True);
 
         await foreach (var node in fs.GetFileNodesAsync("/", "**"))
         {
@@ -114,8 +114,8 @@ public abstract class VirtualFileSystemSpecificationTests(string safePath = "/")
         using var fs = GetFileSystem();
 
         Assert.That(
-            await fs.GetFilesAsync("/", "**").CountAsync(),
-            Is.Not.Zero);
+            await fs.GetFilesAsync("/", "**").AnyAsync(),
+            Is.True);
 
         await foreach (var file in fs.GetFilesAsync("/", "**"))
         {
@@ -148,8 +148,8 @@ public abstract class VirtualFileSystemSpecificationTests(string safePath = "/")
             return;
 
         Assert.That(
-            await fs.GetFilesAsync("/", "**").CountAsync(),
-            Is.Not.Zero);
+            await fs.GetFilesAsync("/", "**").AnyAsync(),
+            Is.True);
 
         await foreach (var file in fs.GetFilesAsync("/", "**"))
         {
@@ -205,8 +205,8 @@ public abstract class VirtualFileSystemSpecificationTests(string safePath = "/")
             return;
 
         Assert.That(
-            await fs.GetFilesAsync("/", "**").CountAsync(),
-            Is.Not.Zero);
+            await fs.GetFilesAsync("/", "**").AnyAsync(),
+            Is.True);
 
         await foreach (var file in fs.GetFilesAsync("/", "**"))
         {
@@ -233,8 +233,8 @@ public abstract class VirtualFileSystemSpecificationTests(string safePath = "/")
             return;
 
         Assert.That(
-            await fs.GetFilesAsync("/", "**").CountAsync(),
-            Is.Not.Zero);
+            await fs.GetFilesAsync("/", "**").AnyAsync(),
+            Is.True);
 
         await foreach (var file in fs.GetFilesAsync("/", "**"))
         {
@@ -324,8 +324,8 @@ public abstract class VirtualFileSystemSpecificationTests(string safePath = "/")
             return;
 
         Assert.That(
-            await fs.GetFilesAsync("/", "**").CountAsync(),
-            Is.Not.Zero);
+            await fs.GetFilesAsync("/", "**").AnyAsync(),
+            Is.True);
 
         await foreach (var file in fs.GetFilesAsync("/", "**"))
         {
@@ -362,8 +362,8 @@ public abstract class VirtualFileSystemSpecificationTests(string safePath = "/")
             return;
 
         Assert.That(
-            await fs.GetFilesAsync("/", "**").CountAsync(),
-            Is.Not.Zero);
+            await fs.GetFilesAsync("/", "**").AnyAsync(),
+            Is.True);
 
         await foreach (var file in fs.GetFilesAsync("/", "**"))
         {
@@ -395,8 +395,8 @@ public abstract class VirtualFileSystemSpecificationTests(string safePath = "/")
             return;
 
         Assert.That(
-            await fs.GetFilesAsync("/", "**").CountAsync(),
-            Is.Not.Zero);
+            await fs.GetFilesAsync("/", "**").AnyAsync(),
+            Is.True);
 
         await foreach (var file in fs.GetFilesAsync("/", "**"))
             Assert.That(() => file.DeleteAsync(), Throws.Exception);
@@ -705,8 +705,8 @@ public abstract class VirtualFileSystemSpecificationTests(string safePath = "/")
             return;
 
         Assert.That(
-            await fs.GetDirectoriesAsync("/", "**").CountAsync(),
-            Is.Not.Zero);
+            await fs.GetDirectoriesAsync("/", "**").AnyAsync(),
+            Is.True);
 
         await foreach (var directory in fs.GetDirectoriesAsync("/", "**"))
             await directory.CreateAsync();


### PR DESCRIPTION
**Add `VirtualNodeProperties.None`:**

Introduced a new static property `VirtualNodeProperties.None` to represent a node with no data instead of:
```csharp
new VirtualNodeProperties(default, default, default, 0);
VirtualNodeProperties.CreateDirectoryProperties(default, default, default);
```

**Optimize test performance:**

Replaced `CountAsync()` with `AnyAsync()` in multiple test assertions where only the presence of items is checked. Since `AnyAsync()` short-circuits on the first element, this reduces enumeration overhead and improves test execution time.