### PR TITLE
Deprecate ZipFileSystem due to thread safety limitations

### DIFF
--- a/src/Ramstack.FileSystem.Zip/README.md
+++ b/src/Ramstack.FileSystem.Zip/README.md
@@ -4,6 +4,18 @@
 
 Provides an implementation of `Ramstack.FileSystem` based on ZIP archives.
 
+> [!CAUTION]
+> The `ZipFileSystem` is **not thread-safe** and allows reading only one file at a time, as it relies on `ZipArchive`,
+> which does not support parallel read operations or simultaneous opening of multiple streams.
+
+> [!WARNING]
+> Due to this limitation, the `ZipFileSystem` class is marked as `[Obsolete]`.
+
+> [!IMPORTANT]
+> You may use `ZipFileSystem` only if you can guarantee that:
+> - Only one file is open for reading at a time.
+> - No file is accessed concurrently.
+
 ## Getting Started
 
 To install the `Ramstack.FileSystem.Zip` [NuGet package](https://www.nuget.org/packages/Ramstack.FileSystem.Zip)

--- a/src/Ramstack.FileSystem.Zip/ZipFileSystem.cs
+++ b/src/Ramstack.FileSystem.Zip/ZipFileSystem.cs
@@ -7,6 +7,21 @@ namespace Ramstack.FileSystem.Zip;
 /// <summary>
 /// Represents a file system backed by a ZIP archive.
 /// </summary>
+/// <remarks>
+/// <b>WARNING:</b>
+/// <para>
+///   The <see cref="ZipFileSystem"/> is not thread-safe and allows reading only one file at a time, as it relies on
+///   <see cref="ZipArchive"/>, which does not support parallel read operations or simultaneous opening of multiple streams.
+/// </para>
+/// <para>
+///   You may use this class only if you can guarantee that:
+///   <list type="bullet">
+///     <item><description>Only one file is open for reading at a time.</description></item>
+///     <item><description>No file is accessed concurrently.</description></item>
+///   </list>
+/// </para>
+/// </remarks>
+[Obsolete("Deprecated due to thread safety limitations and parallel file access capabilities.")]
 public sealed class ZipFileSystem : IVirtualFileSystem
 {
     private readonly ZipArchive _archive;


### PR DESCRIPTION
The `ZipFileSystem` class is marked as `[Obsolete]` because it relies on `ZipArchive`, which does not support parallel read operations or simultaneous stream access, potentially causing more issues than benefits.