### PR TITLE
Clean up, formatting, and maintenance

### DIFF
--- a/src/Ramstack.FileSystem.Abstractions/Utilities/EnumerableExtensions.cs
+++ b/src/Ramstack.FileSystem.Abstractions/Utilities/EnumerableExtensions.cs
@@ -3,7 +3,7 @@ namespace Ramstack.FileSystem.Utilities;
 /// <summary>
 /// Provides extension methods for the <see cref="IEnumerable{T}"/>.
 /// </summary>
-public static class EnumerableExtensions
+internal static class EnumerableExtensions
 {
     /// <summary>
     /// Converts an enumerable sequence to an async-enumerable sequence.

--- a/src/Ramstack.FileSystem.Abstractions/Utilities/PathTokenizer.cs
+++ b/src/Ramstack.FileSystem.Abstractions/Utilities/PathTokenizer.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Ramstack.FileSystem.Utilities;
 
 /// <summary>

--- a/src/Ramstack.FileSystem.Abstractions/VirtualPath.cs
+++ b/src/Ramstack.FileSystem.Abstractions/VirtualPath.cs
@@ -173,7 +173,7 @@ public static class VirtualPath
             for (var j = 1; (uint)j < (uint)path.Length; j++)
             {
                 var ch = path[j];
-                if (ch == '\\' || ch == '/' && prior == '/')
+                if (ch == '\\' || (ch == '/' && prior == '/'))
                     return false;
 
                 if (ch == '.' && prior == '/')

--- a/src/Ramstack.FileSystem.Adapters/Ramstack.FileSystem.Adapters.csproj
+++ b/src/Ramstack.FileSystem.Adapters/Ramstack.FileSystem.Adapters.csproj
@@ -38,6 +38,9 @@
     <Compile Include="..\Ramstack.FileSystem.Abstractions\Properties\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Ramstack.FileSystem.Abstractions\Utilities\EnumerableExtensions.cs">
+      <Link>Utilities\EnumerableExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ramstack.FileSystem.Globbing/GlobbingFileSystem.cs
+++ b/src/Ramstack.FileSystem.Globbing/GlobbingFileSystem.cs
@@ -103,5 +103,5 @@ public sealed class GlobbingFileSystem : IVirtualFileSystem
     /// otherwise, <see langword="false" />.
     /// </returns>
     internal bool IsDirectoryIncluded(string path) =>
-        path == "/" || !PathHelper.IsMatch(path, _excludes) && PathHelper.IsPartialMatch(path, _patterns);
+        path == "/" || (!PathHelper.IsMatch(path, _excludes) && PathHelper.IsPartialMatch(path, _patterns));
 }

--- a/src/Ramstack.FileSystem.Globbing/Internal/PathHelper.cs
+++ b/src/Ramstack.FileSystem.Globbing/Internal/PathHelper.cs
@@ -118,7 +118,7 @@ internal static class PathHelper
         static bool IsGlobStar(ref char s, int index, int final) =>
             index + 2 == final && Unsafe.ReadUnaligned<int>(
                 ref Unsafe.As<char, byte>(
-                    ref Unsafe.Add(ref s, (nint)(uint)index))) == ('*' << 16 | '*');
+                    ref Unsafe.Add(ref s, (nint)(uint)index))) == (('*' << 16) | '*');
     }
 
     #region Vector helper methods

--- a/src/Ramstack.FileSystem.Physical/PhysicalFile.cs
+++ b/src/Ramstack.FileSystem.Physical/PhysicalFile.cs
@@ -59,11 +59,7 @@ internal sealed class PhysicalFile : VirtualFile
     {
         EnsureDirectoryExists();
 
-        var options = Path.DirectorySeparatorChar == '\\'
-            ? FileOptions.Asynchronous | FileOptions.SequentialScan
-            : FileOptions.Asynchronous;
-
-        var stream = new FileStream(_physicalPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None, DefaultBufferSize, options);
+        var stream = new FileStream(_physicalPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None, DefaultBufferSize, FileOptions.Asynchronous);
 
         // Since FileMode.OpenOrCreate doesn't truncate the file, we manually
         // set the file length to zero to remove any leftover data.
@@ -79,16 +75,12 @@ internal sealed class PhysicalFile : VirtualFile
 
         try
         {
-            var options = Path.DirectorySeparatorChar == '\\'
-                ? FileOptions.Asynchronous | FileOptions.SequentialScan
-                : FileOptions.Asynchronous;
-
             // To overwrite the file, we use FileMode.OpenOrCreate instead of FileMode.Create.
             // This avoids a System.UnauthorizedAccessException: Access to the path is denied,
             // which can occur if the file has the FileAttributes.Hidden attribute.
             var fileMode = overwrite ? FileMode.OpenOrCreate : FileMode.CreateNew;
 
-            await using var fs = new FileStream(_physicalPath, fileMode, FileAccess.Write, FileShare.None, DefaultBufferSize, options);
+            await using var fs = new FileStream(_physicalPath, fileMode, FileAccess.Write, FileShare.None, DefaultBufferSize, FileOptions.Asynchronous);
 
             // Since FileMode.OpenOrCreate doesn't truncate the file, we manually
             // set the file length to zero to remove any leftover data.

--- a/src/Ramstack.FileSystem.Physical/PhysicalFile.cs
+++ b/src/Ramstack.FileSystem.Physical/PhysicalFile.cs
@@ -45,7 +45,7 @@ internal sealed class PhysicalFile : VirtualFile
     {
         // SequentialScan is a performance hint that requires extra sys-call on non-Windows systems.
         // https://github.com/dotnet/runtime/blob/46c9a4fff83f35ec659e6659050440aadccf3201/src/libraries/System.Private.CoreLib/src/System/IO/File.cs#L694
-        var options = Path.DirectorySeparatorChar == '\\'
+        var options = OperatingSystem.IsWindows()
             ? FileOptions.Asynchronous | FileOptions.SequentialScan
             : FileOptions.Asynchronous;
 
@@ -108,7 +108,7 @@ internal sealed class PhysicalFile : VirtualFile
             const int WIN32_ERROR_FILE_EXISTS = unchecked((int)0x80070050);
             const int POSIX_EEXIST = 17;
 
-            var exists = Path.DirectorySeparatorChar == '\\'
+            var exists = OperatingSystem.IsWindows()
                 ? exception.HResult == WIN32_ERROR_FILE_EXISTS
                 : exception.HResult == POSIX_EEXIST;
 

--- a/src/Ramstack.FileSystem.Physical/Ramstack.FileSystem.Physical.csproj
+++ b/src/Ramstack.FileSystem.Physical/Ramstack.FileSystem.Physical.csproj
@@ -38,6 +38,9 @@
     <Compile Include="..\Ramstack.FileSystem.Abstractions\Properties\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Ramstack.FileSystem.Abstractions\Utilities\EnumerableExtensions.cs">
+      <Link>Utilities\EnumerableExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ramstack.FileSystem.Prefixed/Ramstack.FileSystem.Prefixed.csproj
+++ b/src/Ramstack.FileSystem.Prefixed/Ramstack.FileSystem.Prefixed.csproj
@@ -38,6 +38,9 @@
     <Compile Include="..\Ramstack.FileSystem.Abstractions\Properties\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Ramstack.FileSystem.Abstractions\Utilities\EnumerableExtensions.cs">
+      <Link>Utilities\EnumerableExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Fix `EnumerableExtensions` visibility
* Use `OperatingSystem.IsWindows()` instead of `Path.DirectorySeparatorChar == '\\'`
* Remove unnecessary `FileOptions.SequentialScan` flag for write operations